### PR TITLE
Decrease RockSlide volume

### DIFF
--- a/src/me/simplicitee/project/addons/ability/earth/RockSlide.java
+++ b/src/me/simplicitee/project/addons/ability/earth/RockSlide.java
@@ -3,6 +3,7 @@ package me.simplicitee.project.addons.ability.earth;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -122,7 +123,9 @@ public class RockSlide extends EarthAbility implements AddonAbility, ComboAbilit
 		direction.setY(dHeight * 0.2);
 		
 		player.setVelocity(direction);
-		playEarthbendingSound(player.getLocation());
+		if (ThreadLocalRandom.current().nextInt(6) == 0) {
+			playEarthbendingSound(player.getLocation());
+		}
 		
 		this.reloadBlocks();
 		


### PR DESCRIPTION
RockSlide is rather noisy, and I think making the sound play at random intervals will reduce the volume. If you'd rather the interval be constant, I can edit this PR to add a counter instead.