### PR TITLE
Yeet: hand having to be empty to switch offhand preset

### DIFF
--- a/src/me/simplicitee/project/addons/MainListener.java
+++ b/src/me/simplicitee/project/addons/MainListener.java
@@ -557,9 +557,6 @@ public class MainListener implements Listener {
 	
 	@EventHandler
 	public void onOffhandToggle(PlayerSwapHandItemsEvent event) {
-		if (event.isCancelled() || event.getMainHandItem().getType() != Material.AIR || event.getOffHandItem().getType() != Material.AIR) {
-			return;
-		}
 		
 		Player player = event.getPlayer();
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);


### PR DESCRIPTION
It's annoying, imagine mid PvP fight and you break some grass and it drops seeds. Suddenly you can't switch presets anymore. In PvE, you kill a zombie, pick up its drops and now you try to switch to your runaway offhand preset but the rotten flesh you picked up disgusts you so much that you fail to change preset.